### PR TITLE
updated the s3 website endpoint to the correct one

### DIFF
--- a/quicksight.yaml
+++ b/quicksight.yaml
@@ -179,7 +179,7 @@ Resources:
     Properties:
       DistributionConfig:
         Origins:
-        - DomainName: !Join [ ".", [ !Ref S3WebSite, !Join [ "-", [ "s3", "website", !Ref 'AWS::Region' ] ], "amazonaws.com" ] ]
+        - DomainName: !Join [ ".", [ !Ref S3WebSite, "s3-website" , !Ref 'AWS::Region', "amazonaws.com" ] ]
           Id: S3WebSite
           CustomOriginConfig:
             HTTPPort: '80'


### PR DESCRIPTION
the old structure was:
<bucket_name>.s3-website-<region>.amazonaws.com
the new one is:
<bucket_name>.s3-website.<region>.amazonaws.com
Notice the period between s3-website to <region>.

*Issue #, if available:*
the endpoint ws changes at some point

*Description of changes:*
the url combination

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
