### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/quicksight.yaml
+++ b/quicksight.yaml
@@ -120,7 +120,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: ./lambda.zip
       Policies: AWSLambdaBasicExecutionRole
       Events:


### PR DESCRIPTION
CloudFormation templates in aws-cognito-quicksight-auth have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.